### PR TITLE
feat: add crawler skeleton

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,5 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy...

--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
-# laravel-otruyen
-laravel-otruyen
+# Laravel OTruyen Admin 📚
+
+Hệ thống quản trị Laravel để crawl và quản lý dữ liệu truyện tranh từ [OTruyen API](https://otruyenapi.com).
+
+## Tính năng chính
+
+- ✅ **Admin Dashboard** đơn giản để quản lý dữ liệu truyện.
+- 🤖 **Crawler Engine** thu thập dữ liệu từ API.
+- 🗄️ **Database Management** lưu trữ truyện đã crawl.
+- 📬 **Queue System** xử lý tác vụ crawl lớn.
+- ⏰ **Scheduled Tasks** tự động hóa việc crawl hàng ngày.
+
+## Cài đặt
+
+```bash
+composer require your-vendor/laravel-otruyen
+```
+
+## Lệnh artisan
+
+```bash
+php artisan otruyen:crawl --store
+```
+
+Lệnh trên sẽ lấy danh sách truyện mới và dispatch job để lấy chi tiết từng truyện.
+
+## Phát triển
+
+> Mở rộng trong thư mục `src/` theo PSR-4: `YourVendor\\Otruyen\\` với các command, job, facade, model, service provider v.v.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,34 @@
+{
+  "name": "your-vendor/laravel-otruyen",
+  "description": "Laravel add-on thu th\u1eadp d\u1eef li\u1ec7u t\u1eeb OTruyen API",
+  "type": "library",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Your Name",
+      "email": "your@email.com"
+    }
+  ],
+  "require": {
+    "php": "^8.1",
+    "illuminate/support": "^10.0|^11.0",
+    "guzzlehttp/guzzle": "^7.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "YourVendor\\Otruyen\\": "src/"
+    }
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "YourVendor\\Otruyen\\OtruyenServiceProvider"
+      ],
+      "aliases": {
+        "Otruyen": "YourVendor\\Otruyen\\Facades\\Otruyen"
+      }
+    }
+  },
+  "minimum-stability": "stable",
+  "prefer-stable": true
+}

--- a/config/otruyen.php
+++ b/config/otruyen.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'base_url' => env('OTRUYEN_API_BASE_URL', 'https://otruyenapi.com'),
+];

--- a/database/migrations/2025_01_01_000000_create_comics_table.php
+++ b/database/migrations/2025_01_01_000000_create_comics_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('comics', function (Blueprint $table) {
+            $table->id();
+            $table->string('slug')->unique();
+            $table->string('title');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('comics');
+    }
+};

--- a/src/Console/CrawlCommand.php
+++ b/src/Console/CrawlCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace YourVendor\Otruyen\Console;
+
+use GuzzleHttp\Client;
+use Illuminate\Console\Command;
+use YourVendor\Otruyen\Jobs\CrawlComicJob;
+
+class CrawlCommand extends Command
+{
+    protected $signature = 'otruyen:crawl {--store : Luu du lieu vao database}';
+    protected $description = 'Fetch latest comics from OTruyen API';
+
+    public function handle(): int
+    {
+        $client = new Client(['base_uri' => config('otruyen.base_url')]);
+        $response = $client->get('/v1/list/truyen-moi');
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        foreach ($data['data'] ?? [] as $item) {
+            CrawlComicJob::dispatch($item['slug'], $this->option('store'));
+        }
+
+        $this->info('Dispatched crawl jobs.');
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Facades/Otruyen.php
+++ b/src/Facades/Otruyen.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace YourVendor\Otruyen\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+class Otruyen extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return 'otruyen';
+    }
+}

--- a/src/Jobs/CrawlComicJob.php
+++ b/src/Jobs/CrawlComicJob.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace YourVendor\Otruyen\Jobs;
+
+use GuzzleHttp\Client;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use YourVendor\Otruyen\Models\Comic;
+
+class CrawlComicJob implements ShouldQueue
+{
+    use InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(protected string $slug, protected bool $store = false)
+    {
+    }
+
+    public function handle(): void
+    {
+        $client = new Client(['base_uri' => config('otruyen.base_url')]);
+        $response = $client->get("/v1/api/truyen/{$this->slug}");
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        if ($this->store && isset($data['data'])) {
+            Comic::updateOrCreate(
+                ['slug' => $this->slug],
+                ['title' => $data['data']['name'] ?? $this->slug]
+            );
+        }
+    }
+}

--- a/src/Models/Comic.php
+++ b/src/Models/Comic.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace YourVendor\Otruyen\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Comic extends Model
+{
+    protected $fillable = ['slug', 'title'];
+}

--- a/src/OtruyenServiceProvider.php
+++ b/src/OtruyenServiceProvider.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace YourVendor\Otruyen;
+
+use GuzzleHttp\Client;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Support\ServiceProvider;
+
+class OtruyenServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__.'/../config/otruyen.php', 'otruyen');
+
+        $this->app->singleton('otruyen', function ($app) {
+            return new Client(['base_uri' => $app['config']['otruyen.base_url']]);
+        });
+    }
+
+    public function boot(): void
+    {
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../config/otruyen.php' => config_path('otruyen.php'),
+            ], 'config');
+
+            $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+            $this->commands([
+                Console\CrawlCommand::class,
+            ]);
+        }
+
+        $this->app->booted(function () {
+            $schedule = $this->app->make(Schedule::class);
+            $schedule->command('otruyen:crawl --store')->daily();
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- set up OTruyen Laravel package skeleton
- add console crawl command, queue job, model, migration and service provider
- document features and usage in README

## Testing
- `find . -name "*.php" -print0 | xargs -0 -n1 php -l`
- `composer validate`
- `composer test` (fails: Command "test" is not defined)
- `phpunit` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a6c144ad808329ab80ae6db90a0021